### PR TITLE
1、Unity2017以上版本拷贝Andorid SDK编辑器报错问题；2、拷贝AB到StreamingAssets目录没有自动重新生成AB服务器地址导致404问题

### DIFF
--- a/Assets/Editor/AssetBundle/AssetbundleMenuItems.cs
+++ b/Assets/Editor/AssetBundle/AssetbundleMenuItems.cs
@@ -172,6 +172,7 @@ namespace AssetBundles
             // 真机上会对比这两个目录下的App版本号来删除，编辑器下暴力一点，直接删除
             ToolsClearPersistentAssets();
             PackageUtils.CopyCurSettingAssetBundlesToStreamingAssets();
+            LaunchAssetBundleServer.CheckAndDoRunning();
         }
 
         [MenuItem(kToolsOpenOutput, false, 1201)]

--- a/Assets/Editor/AssetBundle/LocalServer/LaunchAssetBundleServer.cs
+++ b/Assets/Editor/AssetBundle/LocalServer/LaunchAssetBundleServer.cs
@@ -17,17 +17,16 @@ namespace AssetBundles
         
         public static void CheckAndDoRunning()
         {
+            WriteAssetBundleServerURL();
+
             bool needRunning = AssetBundleConfig.IsSimulateMode;
             bool isRunning = IsRunning();
             if (needRunning != isRunning)
             {
+                KillRunningAssetBundleServer();
                 if (needRunning)
                 {
                     Run();
-                }
-                else
-                {
-                    KillRunningAssetBundleServer();
                 }
             }
         }
@@ -74,9 +73,6 @@ namespace AssetBundles
 
 		static void Run ()
 		{
-			KillRunningAssetBundleServer();
-			WriteAssetBundleServerURL();
-
 			string args = string.Format("\"{0}\" {1}", AssetBundleConfig.LocalSvrAppWorkPath, Process.GetCurrentProcess().Id);
             ProcessStartInfo startInfo = ExecuteInternalMono.GetProfileStartInfoForMono(MonoInstallationFinder.GetMonoInstallation("MonoBleedingEdge"), GetMonoProfileVersion(), AssetBundleConfig.LocalSvrAppPath, args, true);
             startInfo.WorkingDirectory = AssetBundleConfig.LocalSvrAppWorkPath;

--- a/Assets/Editor/PackageBuild/PackageTool.cs
+++ b/Assets/Editor/PackageBuild/PackageTool.cs
@@ -295,7 +295,7 @@ public class PackageTool : EditorWindow
         {
             if (GUILayout.Button("Copy SDK Resources", GUILayout.Width(200)))
             {
-                PackageUtils.CopyAndroidSDKResources(channelType.ToString());
+                EditorApplication.delayCall += CopyAndroidSDKResources;
             }
             if (GUILayout.Button("Current Channel Only", GUILayout.Width(200)))
             {
@@ -315,7 +315,7 @@ public class PackageTool : EditorWindow
         {
             if (GUILayout.Button("Copy SDK Resource", GUILayout.Width(200)))
             {
-                PackageUtils.CopyAndroidSDKResources(channelType.ToString());
+                EditorApplication.delayCall += CopyAndroidSDKResources;
             }
             if (GUILayout.Button("Execute Build", GUILayout.Width(200)))
             {
@@ -591,6 +591,11 @@ public class PackageTool : EditorWindow
         }
         bundleVersion = string.Join(".", vers);
         SaveAllCurrentVersionFile(true);
+    }
+
+    public static void CopyAndroidSDKResources()
+    {
+        PackageUtils.CopyAndroidSDKResources(channelType.ToString());
     }
 
     public static void BuildAndroidPlayerForCurrentChannel()


### PR DESCRIPTION
主干改动合入分支